### PR TITLE
Link content attribute dfns back to the model element

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,32 +186,32 @@
       </p>
       <aside class="issue" data-number="14"></aside>
       <h3>
-        <code><dfn class="element-attr">autoplay</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">autoplay</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">interactive</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">interactive</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">controls</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">controls</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">crossorigin</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">crossorigin</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">height</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">height</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">loading</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">loading</dfn></code> attribute
       </h3>
       <aside class="issue" data-number="44"></aside>
       <h3>
-        <code><dfn class="element-attr">loop</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">loop</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">muted</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">muted</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">poster</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">poster</dfn></code> attribute
       </h3>
       <p>
         The [^model/poster^] attribute gives the URL of an image file that the
@@ -220,10 +220,10 @@
         potentially surrounded by spaces</span>.
       </p>
       <h3>
-        <code><dfn class="element-attr">src</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">src</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr">width</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">width</dfn></code> attribute
       </h3>
     </section>
     <section data-dfn-for="HTMLModelElement">


### PR DESCRIPTION
For cross-referencing purpose, the definitions of the content attributes should be explicitly tied to `model`:
https://respec.org/xref/?term=loading&specs=model-element ... currently proposes `[^/loading^]` instead of `[^model/loading^]`.

Interestingly, this does not seem to bug ReSpec within the spec itself. It correctly resolves links such as `[^model/autoplay^]` there. Magic? ;)

(via https://github.com/w3c/reffy/pull/1515)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/model-element/pull/77.html" title="Last updated on Mar 21, 2024, 8:56 AM UTC (75d2365)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/77/ed579b5...tidoust:75d2365.html" title="Last updated on Mar 21, 2024, 8:56 AM UTC (75d2365)">Diff</a>