### PR TITLE
fix: Use .glb extension with model/gltf-binary

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
         <pre class="html">
            &lt;model&gt; 
               &lt;source src="3d-assets/teapot.usdz" type="model/vnd.pixar.usd"&gt;
-              &lt;source src="3d-assets/teapot.gltf" type="model/gltf-binary"&gt;
+              &lt;source src="3d-assets/teapot.glb" type="model/gltf-binary"&gt;
            &lt;/model&gt;
          </pre>
          `&lt;model&gt;` source selection follows `&lt;video&gt;` selection,


### PR DESCRIPTION
Minor cleanup from #96. The available media types for glTF are:

| extension | media type | link |
|---|---|---|
| .gltf | model/gltf+json | https://www.iana.org/assignments/media-types/model/gltf+json |
| .glb | model/gltf-binary | https://www.iana.org/assignments/media-types/model/gltf-binary |


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/donmccurdy/model-element/pull/98.html" title="Last updated on Oct 7, 2024, 9:16 PM UTC (71dc17f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/98/7d48b5e...donmccurdy:71dc17f.html" title="Last updated on Oct 7, 2024, 9:16 PM UTC (71dc17f)">Diff</a>