### PR TITLE
Remove references to muted

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,9 +270,6 @@
           [^model/loop^] — Whether to loop the media resource
         </dd>
         <dd>
-          [^model/muted^] — Whether to mute the media resource by default
-        </dd>
-        <dd>
           [^model/poster^] — Poster frame to show while the resource is loading
         </dd>
         <dd>
@@ -320,9 +317,6 @@
       <aside class="issue" data-number="44"></aside>
       <h3>
         <code><dfn class="element-attr" data-dfn-for="model">loop</dfn></code> attribute
-      </h3>
-      <h3>
-        <code><dfn class="element-attr" data-dfn-for="model">muted</dfn></code> attribute
       </h3>
       <h3>
         <code><dfn class="element-attr" data-dfn-for="model">poster</dfn></code> attribute
@@ -461,9 +455,6 @@
         Media Playback States (`:playing`, `:paused`, `:seeking`)
       </h3>
       <aside class="issue" data-number="31"></aside>
-      <h3>
-        The `:muted` and `:volume-locked` pseudo-classes
-      </h3>
       <h3>
         Fullscreen Presentation State: the `:fullscreen` pseudo-class
       </h3>


### PR DESCRIPTION
removes the references to volume and muted, as we have resolved not to include audio playback within the model in the initial specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/136.html" title="Last updated on Dec 19, 2025, 10:57 PM UTC (48ef45e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/136/1a4f45f...48ef45e.html" title="Last updated on Dec 19, 2025, 10:57 PM UTC (48ef45e)">Diff</a>