### PR TITLE
Add loading and dimensional IDL entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,9 +348,13 @@
         [Exposed=Window]
         interface HTMLModelElement : HTMLElement {
 
+          readonly attribute Promise<HTMLModelElement> ready;
+          readonly attribute DOMPointReadOnly boundingBoxCenter;
+          readonly attribute DOMPointReadOnly boundingBoxExtents;
+          attribute DOMMatrixReadOnly entityTransform;
+
         };
       </pre>
-      <aside class="issue" data-number="12"></aside>
       <aside class="issue" data-number="42"></aside>
     </section>
     <section>


### PR DESCRIPTION
Added the ready Promise, get/set entityTransform and bounding-box parameters that are used as a successor to the Promise-based `get/setCamera` API initially proposed.

fixes #12

There's a whole lot more IDL currently publicly-defined here:

https://github.com/WebKit/WebKit/blob/main/Source/WebCore/Modules/model-element/HTMLModelElement.idl

but I thought it would be worth pulling in the pieces in based on functionality. Does that make more sense? It's hard to know what the smallest usable PRs are on the issue.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/137.html" title="Last updated on Dec 19, 2025, 11:19 PM UTC (fad7766)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/137/1a4f45f...fad7766.html" title="Last updated on Dec 19, 2025, 11:19 PM UTC (fad7766)">Diff</a>