### PR TITLE
Change references to the interactive attribute to stagemode

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,8 +253,8 @@
           [=Embedded content=].
         </dd>
         <dd>
-          If the element has an `interactive` attribute: [=interactive
-          content=].
+          If the element has its `stagemode` attribute set to a recognized 
+          mode such as `orbit`: [=interactive content=].
         </dd>
         <dd>
           [=Palpable content=].
@@ -294,7 +294,8 @@
           automatically when the page is loaded
         </dd>
         <dd>
-          [^model/interactive^] — Allows the user to interact with the model
+          [^model/stagemode^] — Specifies the mode for interacting with the model,
+          such as `orbit` mode.
         </dd>
         <dd>
           [^model/crossorigin^] — How the element handles crossorigin requests
@@ -339,7 +340,7 @@
         <code><dfn class="element-attr" data-dfn-for="model">autoplay</dfn></code> attribute
       </h3>
       <h3>
-        <code><dfn class="element-attr" data-dfn-for="model">interactive</dfn></code> attribute
+        <code><dfn class="element-attr" data-dfn-for="model">stagemode</dfn></code> attribute
       </h3>
       <h3>
         <code><dfn class="element-attr" data-dfn-for="model">controls</dfn></code> attribute
@@ -386,6 +387,7 @@
           readonly attribute DOMPointReadOnly boundingBoxExtents;
           attribute DOMMatrixReadOnly entityTransform;
 
+          [Reflect] attribute DOMString stageMode;
         };
       </pre>
       <aside class="issue" data-number="42"></aside>


### PR DESCRIPTION
Updated references to interactive,
added the IDL line referring to the updated attribute/property.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/142.html" title="Last updated on Mar 14, 2026, 12:47 AM UTC (674dbf7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/142/33d49e5...674dbf7.html" title="Last updated on Mar 14, 2026, 12:47 AM UTC (674dbf7)">Diff</a>