### PR TITLE
Redefines camera to pose

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,12 +441,13 @@
         The initial <dfn>model fit algorithm</dfn> consists of the following steps.
       </p>
 
-        <ol>
-      
-          <li><p>Determine the <code data-x="dom-model-boundingboxextents">boundingBoxExtents</code>, <var>extents</var>, of the resource and store it in the relevant attribute.</p></li>
-          <li><p>Determine the boundingBoxCenter, <var>center</var>, of the resource and store it in the relevant attribute.</p></li>
+
+      <ol>
+          <li><p>Retrieve the bounds of the smallest axis-aligned box that contains the geometry of the object.</p></li>
+          <li><p>Let <var>extents</var> be the <code data-x="dom-model-boundingboxextents">boundingBoxExtents</code> of the resource.</p></li>
+          <li><p>Let <var>center</var> be the <code data-x="dom-model-boundingboxcenter">boundingBoxCenter</code> of the resource.</p></li>
           <li><p>Divide <var>extents.x</var> by the model's <code data-x="attr-model-width">width</code> in the viewport. This is the X-scale. </p></li>
-          <li><p>Divide <var>extents.y</var> by the model's <code data-x="attr-model-height">height</code> in the viewport. this is the Y-scale.</p></li>
+          <li><p>Divide <var>extents.y</var> by the model's <code data-x="attr-model-height">height</code> in the viewport. This is the Y-scale.</p></li>
           <li><p>scale the <code data-x="dom-model-entitytransform">entityTransform</code> to be the minimum of the X-scale and Y-scale.</p></li>
           <li><p>Set the <code data-x="dom-model-entitytransform">entityTransform</code> to be centered on <var>center.x</var>, <var>center.y </var>and set back from <var>center.z</var> by <var>extents.z / 2</var>, so that the full extents are visible and set directly behind the viewport.</p></li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -437,13 +437,36 @@
         <p>On the initial load for a model, the `entityTransform` MUST be set so that the object is fully in view within the model element's <code data-x="attr-model-width">width</code> and <code data-x="attr-model-height">height</code> on the page.
       
       </p>
+
+      <p>The <dfn>bounding box calculation algorithm</dfn> consists of the following steps.</p>
+
+      <ol>
+        <li><p>With the model scene loaded, set the animation to the first frame if present.</p></li>
+        <li><p>let <var>max</var> be a new `DOMPoint` with values of `-Infinity`.</p></li>
+        <li><p>let <var>min</var> be a new `DOMPoint` with values of `Infinity`.</p></li>
+        <li><p>let <var>queue</var> be an empty list of elements.</p></li>
+        <li><p>Add the model's root object to <var>queue</var>.</p></li>
+        <li><p>While <var>queue</var> is not empty:</p></li>
+        <ol>
+          <li><p>set <var>element</var> to the last element in <var>queue</var> and remove it from <var>queue</var>.</p></li>
+          <li><p>If <var>element</var>contains any child elements, add them to <var>queue</var>.</p></li>
+          <li><p>If <var>element</var> contains renderable geometry, find the minimum and maximum value for the X, Y and Z locations of that geometry.</p></li>
+          <li><p>Apply the world matrix of <var>element</var> to the bounding box of its geometry.</p></li>
+          <li><p>set each value of <var>min</var> to the minimum of its current value and the minimum for this element's bounding box.</p></li>
+          <li><p>set each value of <var>max</var> to the maximum of its current value and the maximum for this element's bounding box.</p></li>
+        </ol>
+        <li><p>Set the values of <var>boundingBoxCenter</var> to be the mean of each values of <var>min</var> and <var>max</var>.</p></li>
+        <li><p>Set the values of <var>boundingBoxExtents</var> to be each value of<var>min</var> subtracted from <var>max</var>.</p></li>
+    </ol>
+
       <p>
         The initial <dfn>model fit algorithm</dfn> consists of the following steps.
       </p>
 
 
       <ol>
-          <li><p>Retrieve the bounds of the smallest axis-aligned box that contains the geometry of the object.</p></li>
+          
+          <li><p>Retrieve the bounds of the smallest axis-aligned box that contains the geometry of the object using the <dfn>bounding box calculation algorithm.</dfn></p></li>
           <li><p>Let <var>extents</var> be the <code data-x="dom-model-boundingboxextents">boundingBoxExtents</code> of the resource.</p></li>
           <li><p>Let <var>center</var> be the <code data-x="dom-model-boundingboxcenter">boundingBoxCenter</code> of the resource.</p></li>
           <li><p>Divide <var>extents.x</var> by the model's <code data-x="attr-model-width">width</code> in the viewport. This is the X-scale. </p></li>

--- a/index.html
+++ b/index.html
@@ -505,8 +505,6 @@
         
         </div>
       </p>
-      <aside class="issue" data-number="42"></aside>
-      <aside class="issue" data-number="41"></aside>
       <h4>Orbit fit</h4>
       <p>The orbit fit algorithm is triggered when the model's `stagemode` is set to `orbit`. The <dfn>orbit fit algorithm</dfn> consists of the following steps.</p>
 

--- a/index.html
+++ b/index.html
@@ -388,7 +388,6 @@
 
         };
       </pre>
-      <aside class="issue" data-number="42"></aside>
     </section>
     <section>
       <h2>
@@ -422,10 +421,50 @@
       <aside class="issue" data-number="48"></aside>
       <aside class="issue" data-number="47"></aside>
       <h3>
-        Orientation/camera
+        Model pose 
       </h3>
-      <aside class="issue" data-number="42"></aside>
-      <aside class="issue" data-number="41"></aside>
+
+
+      <div w-nodev>
+
+        <p>The position, rotation, and scale of a model element's contents are controlled through the 
+        <code data-x="attr-entity-transform">entityTransform</code> property, a 
+        `DOMMatrixReadOnly` that can be composed using that object's existing
+        API. </p>
+        
+        <p>Updates to the <code data-x="attr-entity-transform">entityTransform</code> will be reflected on the next rendered frame. </p> 
+        
+        <p>On the initial load for a model, the `entityTransform` is set so that the object is fully in view within the model element's <code data-x="attr-model-width">width</code> and <code data-x="attr-model-height">height</code> on the page.
+      
+      </p>
+      <p>
+        The initial <dfn>model fit algorithm</dfn> consists of the following steps.
+      </p>
+
+        <ol>
+      
+          <li><p>Determine the <code data-x="dom-model-boundingboxextents">boundingBoxExtents</code>, <var>extents</var>, of the resource and store it in the relevant attribute.</p></li>
+          <li><p>Determine the boundingBoxCenter, <var>center</var>, of the resource and store it in the relevant attribute.</p></li>
+          <li><p>Divide <var>extents.x</var> by the model's <code data-x="attr-model-width">width</code> in the viewport. This is the X-scale. </p></li>
+          <li><p>Divide <var>extents.y</var> by the model's <code data-x="attr-model-height">height</code> in the viewport. this is the Y-scale.</p></li>
+          <li><p>scale the <code data-x="dom-model-entitytransform">entityTransform</code> to be the minimum of the X-scale and Y-scale.</p></li>
+          <li><p>Set the <code data-x="dom-model-entitytransform">entityTransform</code> to be centered on <var>center.x</var>, <var>center.y </var>and set back from <var>center.z</var> by <var>extents.z / 2</var>, so that the full extents are visible and set directly behind the viewport.</p></li>
+        </ol>
+
+        <aside class="note">
+          <p>
+          This algorithm is executed only on the initial load of the element, at its initial page dimensions. Subsequent changes to the model's <code data-x="attr-model-width">width</code> or <code data-x="attr-model-height">height</code> will not automatically trigger a change in the <code data-x="dom-model-entitytransform">entityTransform</code>.
+          </p>
+        </aside>
+        
+        <aside class="note">
+          <p>
+         Given that the <code data-x="dom-model-entitytransform">entityTransform</code> is determinative of the model's fit on the page, resetting to the initial pose can be achieved by storing this initial value and re-applying it at any point in the future.
+          </p>
+        </aside>
+        
+        </div>
+      </p>
       <h3>
         Embedded content
       </h3>

--- a/index.html
+++ b/index.html
@@ -427,14 +427,14 @@
 
       <div w-nodev>
 
-        <p>The position, rotation, and scale of a model element's contents are controlled through the 
+        <p>The The position, rotation, and scale of a displayed model MUST present its contents according to its 
         <code data-x="attr-entity-transform">entityTransform</code> property, a 
         `DOMMatrixReadOnly` that can be composed using that object's existing
         API. </p>
         
-        <p>Updates to the <code data-x="attr-entity-transform">entityTransform</code> will be reflected on the next rendered frame. </p> 
+        <p>Updates to the <code data-x="attr-entity-transform">entityTransform</code> SHOULD be reflected on the next rendered frame. </p> 
         
-        <p>On the initial load for a model, the `entityTransform` is set so that the object is fully in view within the model element's <code data-x="attr-model-width">width</code> and <code data-x="attr-model-height">height</code> on the page.
+        <p>On the initial load for a model, the `entityTransform` MUST be set so that the object is fully in view within the model element's <code data-x="attr-model-width">width</code> and <code data-x="attr-model-height">height</code> on the page.
       
       </p>
       <p>


### PR DESCRIPTION
Updates the section relating to camera and orientation to reflect the discussion of leveraging the `DOMMatrix` object as an `entityTransform` over the model, per discussions in the CG.

Fixes #42
Fixes #41


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/144.html" title="Last updated on Mar 16, 2026, 7:50 PM UTC (23efab4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/144/33d49e5...23efab4.html" title="Last updated on Mar 16, 2026, 7:50 PM UTC (23efab4)">Diff</a>