### PR TITLE
defines ready Promise role

### DIFF
--- a/index.html
+++ b/index.html
@@ -449,7 +449,10 @@
       <h2>
         Events
       </h2>
-      <aside class="issue" data-number="26"></aside>
+      <p>
+        The [^model^] element emits a  <code>ready</code> <span data-x="idl-Promise">Promise</span> when the model is processed and ready to display. The Promise is rejected if the model source cannot be loaded.
+      </p>
+
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Adds a definition of the `ready` Promise.

fixes #26


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/145.html" title="Last updated on Feb 12, 2026, 10:27 PM UTC (ce67554)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/145/973ad0e...ce67554.html" title="Last updated on Feb 12, 2026, 10:27 PM UTC (ce67554)">Diff</a>