### PR TITLE
Introduces lighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,7 +384,11 @@
           readonly attribute Promise&lt;HTMLModelElement&gt; ready;
           readonly attribute DOMPointReadOnly boundingBoxCenter;
           readonly attribute DOMPointReadOnly boundingBoxExtents;
+
           attribute DOMMatrixReadOnly entityTransform;
+
+          attribute USVString environmentMap;
+          readonly attribute <span data-x="idl-Promise">Promise</span>&lt;undefined> <span data-x="dom-model-environmentMapReady">environmentMapReady</span>;
 
         };
       </pre>
@@ -417,10 +421,14 @@
       <h2>
         Rendering
       </h2>
+      <p>The model SHOULD be rendered according to a realtime, physically-based rendering (PBR) shading model, and lit by an image-based light.</p>
+
+      <h3>Environment map</h3>
+      <p>If provided, an environment map MUST be interpreted as an equirectangular environment map. If an environmentMap is not specified, the User Agent MUST provide an appropriate map.</p>
+
+
       <aside class="issue" data-number="1"></aside>
       <aside class="issue" data-number="5"></aside>
-      <aside class="issue" data-number="48"></aside>
-      <aside class="issue" data-number="47"></aside>
       <h3>
         Orientation/camera
       </h3>
@@ -450,6 +458,7 @@
         Events
       </h2>
       <aside class="issue" data-number="26"></aside>
+      <p> The <code data-x="dom-model-environmentMapReady">environmentMapReady</code> <code data-x="idl-Promise">Promise</code> resolves when an environment map resource has been loaded, or is rejected if the resource is unable to be loaded.</p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Added the environmentMap attribute and environmentMapReady promise to the IDL, Added initial language about the use of a PBR shading model and IBL. 

I'm open to more granular specification of the requirements here, but I think we would be better off referencing some other specification, or to add language that indicates that these are UA/OS decisions.

I don't believe anyone has an interest in providing a ground shadow for the in-line element, so I've also removed the issue related to that. 

fixes #48
fixes #47


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/146.html" title="Last updated on Mar 13, 2026, 11:24 PM UTC (74c6409)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/146/ee03ade...74c6409.html" title="Last updated on Mar 13, 2026, 11:24 PM UTC (74c6409)">Diff</a>