### PR TITLE
Withdraws from AR Quick Look-related concerns

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,6 @@
         Interaction
       </h2>
       <aside class="issue" data-number="2"></aside>
-      <aside class="issue" data-number="46"></aside>
     </section>
     <aside class="issue" data-number="25"></aside>
     <section>
@@ -485,10 +484,6 @@
           We need to figure out which apply to [^model^].
         </p>
       </aside>
-      <h3>
-        Link rel="ar"
-      </h3>
-      <aside class="issue" data-number="45"></aside>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Removed references to AR Quick Look and the `rel=ar` syntax, as these are only superficially-related concepts.

fixes #45
fixes #46

We can keep this if people feel like there's a clearer link between the functionalities, but AFAIK this is only currently relevant on our platforms, and we don't have a need to relate the technologies in this way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/148.html" title="Last updated on Feb 14, 2026, 1:16 AM UTC (66f2772)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/148/973ad0e...66f2772.html" title="Last updated on Feb 14, 2026, 1:16 AM UTC (66f2772)">Diff</a>