### PR TITLE
Add autoplay hint information

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,6 +338,7 @@
       <h3>
         <code><dfn class="element-attr" data-dfn-for="model">autoplay</dfn></code> attribute
       </h3>
+      <p>Hint that the model can start its animation automatically, if present, when the asset is loaded.</p>
       <h3>
         <code><dfn class="element-attr" data-dfn-for="model">stagemode</dfn></code> attribute
       </h3>


### PR DESCRIPTION
Added indication that it's a hint, as well as that an animation is not _necessarily_ present.

Is it necessary to add a note indicating that UAs may ignore it based on accessibility settings etc, or is that implied?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/149.html" title="Last updated on Mar 18, 2026, 12:16 AM UTC (9809933)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/149/2ba6816...9809933.html" title="Last updated on Mar 18, 2026, 12:16 AM UTC (9809933)">Diff</a>