### PR TITLE
Specify the fetch destinations for model and environmentmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -609,7 +609,9 @@
       <h3>
         `"model"` destination
       </h3>
-      <aside class="issue" data-number="35"></aside>
+      <p>
+        Resources requested for the purposes of model content MUST set the `sec-fetch-dest` field to `model` in its request header. Similarly, resources requested as environment maps MUST set the `sec-fetch-dest` to `environmentmap`.
+      </p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
specify the fetch destinations for model and environmentmap.

fixes #35

(I'm not sure if this necessitates changes in more places, it wasn't clear from other specs when/how these things are described)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/150.html" title="Last updated on Mar 27, 2026, 10:28 PM UTC (39c4b47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/150/f7f0ec3...39c4b47.html" title="Last updated on Mar 27, 2026, 10:28 PM UTC (39c4b47)">Diff</a>