### PR TITLE
Describe inline fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,7 +600,12 @@
       <h2>
         Fullscreen integration
       </h2>
-      <aside class="issue" data-number="31"></aside>
+      <p>
+        Model elements in fullscreen mode, as invoked through `model.reqeustFullscreen(),` are presented in-line in the full-screen window. 
+        <aside class="note">
+          On spatial platforms that do not have a fixed maximum region of display, the specific behavior of fullscreen may be unexpected. An example implementation may retain a window of the original boundary and aspect ratio of the browser window, presenting the target element as the sole contents of the browser window. 
+        </aside>
+      </p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Specify that requestFullscreen sends the model into an in-line full-screen mode, 
Added a non-normative note about the _kind_ of behavior that some (all?) of the spatial browsers currently seem to agree on as an interpretation for `requestFullscreen()`

(I think the listed issue was meant to be 34 rather than a dupe of 31) 

fixes #34

@toji are there more general obligations we should try to meet to describe / agree on a spatial browser's fullscreen? It's definitely _convenient_ that we all seem to agree so far!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/pull/151.html" title="Last updated on Mar 27, 2026, 11:38 PM UTC (33f2c91)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/model-element/151/f7f0ec3...33f2c91.html" title="Last updated on Mar 27, 2026, 11:38 PM UTC (33f2c91)">Diff</a>